### PR TITLE
add mofdscribe package to toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
   "radonpy-pypi",
   "rdkit",
   "matplotlib",
+  ""mofdscribe @ git+https://github.com/kjappelbaum/mofdscribe.git@main#subdirectory=src/mofdscribe"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Add mofdscribe package to pyproject.toml.