### PR TITLE
add mkdocs dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
   "pytest-cov",
   "ruff",
   "bump-my-version",
+  "mkdocs",
   "mkdocs-material",
   "mkdocstrings[python]",
 ]


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Add mkdocs, mkdocs-material, and mkdocstrings[python] as development dependencies.