### PR TITLE
add polymerclass splitter and dataset for polymerclass

### DIFF
--- a/src/polymetrix/datasets/curated_tg_dataset.py
+++ b/src/polymetrix/datasets/curated_tg_dataset.py
@@ -18,7 +18,7 @@ class CuratedGlassTempDataset(AbstractDataset):
     META_PREFIX = "meta."
 
     DEFAULT_VERSION = "v1"
-    DEFAULT_URL = "https://zenodo.org/records/14980914/files/LAMALAB_CURATED_Tg_structured.csv?download=1"
+    DEFAULT_URL = "https://zenodo.org/records/15210035/files/LAMALAB_CURATED_Tg_structured_polymerclass.csv?download=1"
 
     def __init__(
         self,
@@ -26,10 +26,10 @@ class CuratedGlassTempDataset(AbstractDataset):
         subset: Optional[Collection[int]] = None,
     ):
         """Initialize the Tg dataset.
-         Args:
-            feature_levels (List[str]): Feature levels to include
-            subset (Optional[Collection[int]]): Indices to include in the dataset
-         """
+        Args:
+           feature_levels (List[str]): Feature levels to include
+           subset (Optional[Collection[int]]): Indices to include in the dataset
+        """
         super().__init__()
         self._version = self.DEFAULT_VERSION
         self._url = self.DEFAULT_URL

--- a/src/polymetrix/splitters/splitters.py
+++ b/src/polymetrix/splitters/splitters.py
@@ -37,3 +37,23 @@ class TgSplitter(BaseSplitter):
             idx=range(len(self._ds)), label_names=[self._label_name]
         ).flatten()
         return quantile_binning(tg_values, self._grouping_q)
+
+
+class PolymerClassSplitter(BaseSplitter):
+    """Splitter based on polymer class"""
+
+    def __init__(
+        self,
+        ds: AbstractDataset,
+        column_name: str = "meta.polymer_class",
+        shuffle: bool = True,
+        random_state: Optional[Union[int, np.random.RandomState]] = None,
+        **kwargs,
+    ) -> None:
+        self._column_name = column_name
+        super().__init__(ds=ds, shuffle=shuffle, random_state=random_state, **kwargs)
+
+    def _get_groups(self) -> Collection[str]:
+        col_idx = self._ds._meta_names.index(self._column_name)
+        metadata = self._ds._meta_data[:, col_idx]
+        return metadata.flatten()


### PR DESCRIPTION
## Summary by Sourcery

Add a new splitter for polymer class and update the Curated Glass Temperature dataset with a new URL

New Features:
- Introduce PolymerClassSplitter to split datasets based on polymer class metadata

Enhancements:
- Update CuratedGlassTempDataset with a new Zenodo record URL that includes polymer class information