### PR TITLE
Bigsmiles extend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+bigsmies = [
+  "bigsmiles==0.0.10",
+  "setuptools<81",
+]
 dev = [
   "jupyter",
   "docformatter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-bigsmies = [
+bigsmiles = [
   "bigsmiles==0.0.10",
   "setuptools<81",
 ]

--- a/src/polymetrix/bigsmiles/__init__.py
+++ b/src/polymetrix/bigsmiles/__init__.py
@@ -1,0 +1,12 @@
+"""BigSMILES support for PolyMetriX.
+
+Public API:
+    BigSmilesPolymer  -- BigSMILES-backed polymer with backbone/sidechain
+                         classification and JSON storage, compatible with the
+                         existing PolyMetriX featurizer and splitter stack.
+    RepeatUnit        -- one classified stochastic fragment (repeat unit).
+"""
+
+from polymetrix.bigsmiles.bigsmiles_polymer import BigSmilesPolymer, RepeatUnit
+
+__all__ = ["BigSmilesPolymer", "RepeatUnit"]

--- a/src/polymetrix/bigsmiles/bigsmiles_polymer.py
+++ b/src/polymetrix/bigsmiles/bigsmiles_polymer.py
@@ -1,0 +1,369 @@
+from typing import List, Optional, Tuple, Dict, Any
+import json
+
+import networkx as nx
+from rdkit import Chem
+from rdkit.Chem.Descriptors import ExactMolWt
+
+from polymetrix.featurizers.polymer import classify_backbone_and_sidechains
+from polymetrix.bigsmiles.bigsmiles_utils import (
+    parse_bigsmiles,
+    stochastic_fragment_graphs,
+    repeat_unit_graphs,
+    normalize_bigsmiles,
+    _iter_stochastic_objects,
+    end_group_atoms,
+    graph_to_mol,
+    mol_to_smiles,
+)
+
+
+class RepeatUnit:
+    """One stochastic fragment (repeat unit) of a BigSMILES polymer.
+
+    Attributes:
+        index: Position of this repeat unit within the polymer.
+        graph: NetworkX graph of the repeat unit (bonding descriptors are ``*``).
+        backbone_nodes: Node keys classified as backbone.
+        sidechain_nodes: Node keys classified as sidechain.
+        connection_points: Node keys of the bonding descriptors.
+    """
+
+    def __init__(self, index: int, graph: nx.Graph):
+        self.index = index
+        self.graph = graph
+        backbone, sidechain = classify_backbone_and_sidechains(graph)
+        self.backbone_nodes = backbone
+        self.sidechain_nodes = sidechain
+        self.connection_points = [
+            node for node, data in graph.nodes(data=True) if data.get("element") == "*"
+        ]
+
+    @property
+    def backbone_molecule(self) -> Chem.Mol:
+        """RDKit mol of this repeat unit's backbone (``*``-terminated)."""
+        return graph_to_mol(self.graph, self.backbone_nodes)
+
+    @property
+    def sidechain_molecules(self) -> List[Chem.Mol]:
+        """RDKit mols of this repeat unit's sidechains (one per component)."""
+        return [
+            graph_to_mol(self.graph, list(component))
+            for component in nx.connected_components(
+                self.graph.subgraph(self.sidechain_nodes)
+            )
+        ]
+
+    @property
+    def backbone_smiles(self) -> str:
+        """SMILES of the backbone."""
+        return mol_to_smiles(self.backbone_molecule)
+
+    @property
+    def sidechain_smiles(self) -> List[str]:
+        """SMILES of each sidechain."""
+        return [mol_to_smiles(m) for m in self.sidechain_molecules]
+
+    @property
+    def full_molecule(self) -> Chem.Mol:
+        """RDKit mol of the whole repeat unit (backbone + sidechains)."""
+        return graph_to_mol(self.graph, list(self.graph.nodes))
+
+    @property
+    def backbone_and_sidechain_smiles(self) -> str:
+        """Canonical pSMILES of the whole repeat unit (``*``-terminated)."""
+        return mol_to_smiles(self.full_molecule)
+
+    @property
+    def descriptors(self) -> List[str]:
+        """Bonding-descriptor labels ([$]/[<]/[>]) of the connection points."""
+        return [
+            self.graph.nodes[node].get("descriptor") for node in self.connection_points
+        ]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialise this repeat unit's classification to a plain dict."""
+        return {
+            "index": self.index,
+            "backbone_smiles": self.backbone_smiles,
+            "sidechain_smiles": self.sidechain_smiles,
+            "descriptors": self.descriptors,
+            "num_backbone_atoms": sum(
+                1
+                for n in self.backbone_nodes
+                if self.graph.nodes[n].get("element") != "*"
+            ),
+            "num_sidechains": len(self.sidechain_molecules),
+        }
+
+
+class BigSmilesPolymer:
+    """Represents a polymer parsed from a BigSMILES string.
+
+    Attributes:
+        bigsmiles: The BigSMILES string of the polymer.
+        repeat_units: List of :class:`RepeatUnit`, one per stochastic fragment.
+        end_groups: Element symbols of explicit end-group atoms (may be empty).
+        graph: A combined NetworkX graph over all repeat units (namespaced keys).
+        backbone_nodes / sidechain_nodes / connection_points: combined node keys.
+    """
+
+    def __init__(self):
+        self._bigsmiles: Optional[str] = None
+        self._bs_obj = None
+        self.repeat_units: List[RepeatUnit] = []
+        self.end_groups: List[str] = []
+        self.graph: Optional[nx.Graph] = None
+        self.backbone_nodes: Optional[List] = None
+        self.sidechain_nodes: Optional[List] = None
+        self.connection_points: Optional[List] = None
+
+    # ------------------------------------------------------------------ #
+    # Construction
+    # ------------------------------------------------------------------ #
+    @classmethod
+    def from_bigsmiles(cls, bigsmiles_str: str) -> "BigSmilesPolymer":
+        """Create a ``BigSmilesPolymer`` from a BigSMILES string.
+
+        Args:
+            bigsmiles_str: The BigSMILES string.
+
+        Returns:
+            A new ``BigSmilesPolymer`` instance.
+
+        Raises:
+            ValueError: If the BigSMILES string is invalid or contains no
+                stochastic repeat unit.
+        """
+        polymer = cls()
+        polymer.bigsmiles = bigsmiles_str
+        return polymer
+
+    @property
+    def bigsmiles(self) -> Optional[str]:
+        """The BigSMILES string of the polymer."""
+        return self._bigsmiles
+
+    @bigsmiles.setter
+    def bigsmiles(self, value: str):
+        if not value or not isinstance(value, str):
+            raise ValueError("BigSMILES cannot be None or empty")
+        fragment_graphs = repeat_unit_graphs(value)
+        if not fragment_graphs:
+            raise ValueError(
+                "No stochastic repeat unit found in BigSMILES "
+                f"'{value}'. A repeat unit must be enclosed in {{...}}."
+            )
+        # End groups are read from the whole-string parse. For a single
+        # stochastic object this is exact; block copolymers (concatenated
+        # objects) can consume a middle block's descriptors at the junctions
+        # and fail the whole-string parse — in that case fall back to no
+        # recorded end groups (the repeat units are still parsed per block).
+        try:
+            self._bs_obj = parse_bigsmiles(value)
+            self.end_groups = end_group_atoms(self._bs_obj)
+        except ValueError:
+            self._bs_obj = None
+            self.end_groups = []
+        self._bigsmiles = value
+        self.repeat_units = [
+            RepeatUnit(i, graph) for i, (frag, graph) in enumerate(fragment_graphs)
+        ]
+        self._build_combined_graph()
+
+    def _build_combined_graph(self):
+        """Build one graph spanning all repeat units with namespaced node keys.
+
+        Keys become ``(unit_index, original_key)`` so nodes from different
+        repeat units never collide; classification results are copied over.
+        """
+        combined = nx.Graph()
+        backbone, sidechain, connections = [], [], []
+        for unit in self.repeat_units:
+            remap = {node: (unit.index, node) for node in unit.graph.nodes}
+            for node, data in unit.graph.nodes(data=True):
+                combined.add_node(remap[node], **data)
+            for u, v, data in unit.graph.edges(data=True):
+                combined.add_edge(remap[u], remap[v], **data)
+            backbone.extend(remap[n] for n in unit.backbone_nodes)
+            sidechain.extend(remap[n] for n in unit.sidechain_nodes)
+            connections.extend(remap[n] for n in unit.connection_points)
+        self.graph = combined
+        self.backbone_nodes = backbone
+        self.sidechain_nodes = sidechain
+        self.connection_points = connections
+
+    # ------------------------------------------------------------------ #
+    # Featurizer-facing interface (mirrors Polymer)
+    # ------------------------------------------------------------------ #
+    @property
+    def mol(self) -> Chem.Mol:
+        """Full polymer molecule (all repeat units), for generic featurizers."""
+        return self.full_polymer_mol
+
+    @property
+    def full_polymer_mol(self) -> Chem.Mol:
+        """Combined RDKit mol over every repeat unit (``*``-terminated)."""
+        return graph_to_mol(self.graph, list(self.graph.nodes))
+
+    @property
+    def psmiles(self) -> str:
+        """Equivalent pSMILES string (``*``-terminated repeat unit).
+
+        This is the BigSMILES → pSMILES bridge. For a homopolymer it is the
+        canonical pSMILES of the single repeat unit; for a copolymer the repeat
+        units are returned as a dot-disconnected pSMILES. It lets pSMILES-only
+        featurizers (e.g. ``FullPolymerFeaturizer``, which reads
+        ``polymer.psmiles``) run on a BigSMILES polymer unchanged.
+        """
+        parts = [unit.backbone_and_sidechain_smiles for unit in self.repeat_units]
+        return ".".join(p for p in parts if p)
+
+    @property
+    def backbone_molecule(self) -> Chem.Mol:
+        """Backbone mol of the first repeat unit (parity with ``Polymer``)."""
+        return self.repeat_units[0].backbone_molecule
+
+    @property
+    def backbone_molecules(self) -> List[Chem.Mol]:
+        """Backbone mol of every repeat unit."""
+        return [unit.backbone_molecule for unit in self.repeat_units]
+
+    @property
+    def sidechain_molecules(self) -> List[Chem.Mol]:
+        """All sidechain mols across every repeat unit."""
+        mols: List[Chem.Mol] = []
+        for unit in self.repeat_units:
+            mols.extend(unit.sidechain_molecules)
+        return mols
+
+    def get_backbone_and_sidechain_molecules(
+        self,
+    ) -> Tuple[List[Chem.Mol], List[Chem.Mol]]:
+        """Return ``([backbone mols], [sidechain mols])``.
+
+        Matches the tuple shape used by ``Polymer`` so the existing featurizers
+        work unchanged. For a copolymer the backbone list has one entry per
+        repeat unit and the sidechain list pools all sidechains.
+        """
+        return self.backbone_molecules, self.sidechain_molecules
+
+    def get_backbone_and_sidechain_graphs(
+        self,
+    ) -> Tuple[List[nx.Graph], List[nx.Graph]]:
+        """Return ``([backbone graphs], [sidechain graphs])`` across all units."""
+        backbone_graphs = [
+            unit.graph.subgraph(unit.backbone_nodes) for unit in self.repeat_units
+        ]
+        sidechain_graphs = []
+        for unit in self.repeat_units:
+            for component in nx.connected_components(
+                unit.graph.subgraph(unit.sidechain_nodes)
+            ):
+                sidechain_graphs.append(unit.graph.subgraph(component))
+        return backbone_graphs, sidechain_graphs
+
+    def calculate_molecular_weight(self) -> float:
+        """Exact molecular weight of the full (``*``-terminated) polymer mol."""
+        mol = self.full_polymer_mol
+        if mol is None or mol.GetNumAtoms() == 0:
+            return 0.0
+        try:
+            work = Chem.Mol(mol)
+            Chem.SanitizeMol(work)
+            return ExactMolWt(work)
+        except Exception:
+            return ExactMolWt(mol)
+
+    def get_connection_points(self) -> List:
+        """Combined connection-point node keys."""
+        return self.connection_points
+
+    @property
+    def num_repeat_units(self) -> int:
+        """Number of stochastic fragments (repeat units)."""
+        return len(self.repeat_units)
+
+    @property
+    def is_copolymer(self) -> bool:
+        """True if the polymer has more than one distinct repeat unit."""
+        return len(self.repeat_units) > 1
+
+    @property
+    def copolymer_type(self) -> str:
+        """Classify the copolymer architecture from the BigSMILES notation.
+
+        Following the BigSMILES paper (Lin et al., *ACS Cent. Sci.* 2019), the
+        two ways of writing multi-component polymers map to distinct
+        architectures:
+
+        * ``"homopolymer"`` — a single repeat unit.
+        * ``"random"`` — one stochastic object with comma-separated fragments,
+          e.g. ``{[$]CC[$],[$]CC(c1ccccc1)[$]}``. The repeat units share the
+          same stochastic block (statistical/random sequence).
+        * ``"block"`` — several stochastic objects concatenated, e.g.
+          ``{[$]CC[$]}{[$]CC(c1ccccc1)[$]}``. Each object is its own block.
+
+        Returns:
+            One of ``"homopolymer"``, ``"random"`` or ``"block"``.
+        """
+        if len(self.repeat_units) <= 1:
+            return "homopolymer"
+        n_objects = len(
+            list(_iter_stochastic_objects(normalize_bigsmiles(self._bigsmiles)))
+        )
+        return "block" if n_objects > 1 else "random"
+
+    # ------------------------------------------------------------------ #
+    # Storage / serialisation
+    # ------------------------------------------------------------------ #
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialise the polymer to a JSON-safe dict.
+
+        The dict is stable and inspectable: it records the source BigSMILES,
+        end groups, and per repeat unit the backbone SMILES, sidechain SMILES,
+        and descriptor labels. It is sufficient to rebuild the object via
+        :meth:`from_dict`.
+        """
+        return {
+            "bigsmiles": self._bigsmiles,
+            "num_repeat_units": self.num_repeat_units,
+            "is_copolymer": self.is_copolymer,
+            "copolymer_type": self.copolymer_type,
+            "end_groups": self.end_groups,
+            "molecular_weight": self.calculate_molecular_weight(),
+            "repeat_units": [unit.to_dict() for unit in self.repeat_units],
+        }
+
+    def to_json(self, indent: int = 2) -> str:
+        """Serialise to a JSON string."""
+        return json.dumps(self.to_dict(), indent=indent)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "BigSmilesPolymer":
+        """Rebuild a ``BigSmilesPolymer`` from a serialised dict.
+
+        Reconstruction re-parses the stored ``bigsmiles`` string (the source of
+        truth), so classification is regenerated deterministically.
+
+        Args:
+            data: A dict produced by :meth:`to_dict`.
+
+        Returns:
+            A ``BigSmilesPolymer`` instance.
+        """
+        bigsmiles_str = data.get("bigsmiles")
+        if not bigsmiles_str:
+            raise ValueError("Serialised data has no 'bigsmiles' key")
+        return cls.from_bigsmiles(bigsmiles_str)
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "BigSmilesPolymer":
+        """Rebuild a ``BigSmilesPolymer`` from a JSON string."""
+        return cls.from_dict(json.loads(json_str))
+
+    def __repr__(self) -> str:
+        return (
+            f"BigSmilesPolymer({self._bigsmiles!r}, "
+            f"repeat_units={self.num_repeat_units})"
+        )

--- a/src/polymetrix/bigsmiles/bigsmiles_polymer.py
+++ b/src/polymetrix/bigsmiles/bigsmiles_polymer.py
@@ -8,7 +8,6 @@ from rdkit.Chem.Descriptors import ExactMolWt
 from polymetrix.featurizers.polymer import classify_backbone_and_sidechains
 from polymetrix.bigsmiles.bigsmiles_utils import (
     parse_bigsmiles,
-    stochastic_fragment_graphs,
     repeat_unit_graphs,
     normalize_bigsmiles,
     _iter_stochastic_objects,

--- a/src/polymetrix/bigsmiles/bigsmiles_utils.py
+++ b/src/polymetrix/bigsmiles/bigsmiles_utils.py
@@ -1,0 +1,440 @@
+import re
+from typing import List, Tuple, Dict, Any
+
+import networkx as nx
+from rdkit import Chem
+from rdkit.Chem import RWMol, Atom, GetPeriodicTable
+
+try:  # bigsmiles is an optional dependency
+    import bigsmiles as _bigsmiles
+except ImportError:  # pragma: no cover
+    _bigsmiles = None
+
+_PT = GetPeriodicTable()
+
+# BigSMILES bond symbol -> RDKit bond type
+_BOND_TYPE_MAP = {
+    "": Chem.BondType.SINGLE,
+    "-": Chem.BondType.SINGLE,
+    "=": Chem.BondType.DOUBLE,
+    "#": Chem.BondType.TRIPLE,
+    ":": Chem.BondType.AROMATIC,
+    "/": Chem.BondType.SINGLE,
+    "\\": Chem.BondType.SINGLE,
+}
+
+
+def require_bigsmiles():
+    """Return the imported ``bigsmiles`` module, or raise a helpful error."""
+    if _bigsmiles is None:  # pragma: no cover
+        raise ImportError(
+            "The 'bigsmiles' package is required for BigSMILES support. "
+            "Install it with `pip install bigsmiles`."
+        )
+    return _bigsmiles
+
+
+# A bare bonding descriptor is ``<``, ``>`` or ``$`` optionally followed by an
+# index (e.g. ``<1``) and NOT already wrapped in square brackets.
+_BARE_DESCRIPTOR = re.compile(r"(?<!\[)([<>$])(\d*)(?!\])")
+
+
+def _iter_stochastic_objects(text: str):
+    """Yield ``(start, end, inner)`` for each top-level ``{...}`` span.
+
+    ``start`` / ``end`` are the indices of the ``{`` and ``}`` characters and
+    ``inner`` is the text between them.
+    """
+    i, n = 0, len(text)
+    while i < n:
+        if text[i] == "{":
+            j = text.index("}", i)
+            yield i, j, text[i + 1 : j]
+            i = j + 1
+        else:
+            i += 1
+
+
+def _rebuild(text: str, replacements: Dict[int, Tuple[int, str]]) -> str:
+    """Rebuild ``text`` applying ``{start: (end, new_inner)}`` replacements."""
+    out: List[str] = []
+    i, n = 0, len(text)
+    while i < n:
+        if i in replacements:
+            j, new_inner = replacements[i]
+            out.append("{" + new_inner + "}")
+            i = j + 1
+        else:
+            out.append(text[i])
+            i += 1
+    return "".join(out)
+
+
+def _expand_simplified(text: str) -> str:
+    """Expand the paper's *simplified* form ``{CC}`` -> ``{[$]CC[$]}``.
+
+    In the BigSMILES paper (Lin et al., ACS Cent. Sci. 2019, §2.3) the bonding
+    descriptor may be omitted when the repeat unit has exactly two terminal
+    connection sites of a single bond type, e.g. polyethylene ``{CC}``, PEG
+    ``{CCO}``, polystyrene ``{CC(c1ccccc1)}``. The omitted descriptor is the
+    symmetric ``$``, so we restore it at both termini.
+    """
+    repl: Dict[int, Tuple[int, str]] = {}
+    for i, j, inner in _iter_stochastic_objects(text):
+        has_desc = any(d in inner for d in ("[<]", "[>]", "[$]", "[]"))
+        if inner and not has_desc and "," not in inner:
+            repl[i] = (j, "[$]" + inner + "[$]")
+    return _rebuild(text, repl)
+
+
+def _inject_endgroups(text: str) -> str:
+    """Add ``[]`` end-group placeholders to *standalone* stochastic objects.
+
+    The parser requires a stochastic object that is not bonded to an external
+    atom to carry explicit end-group placeholders, i.e. ``{[$]CC[$]}`` must be
+    written ``{[][$]CC[$][]}``. A terminus that is bonded to a real atom (or a
+    disconnection ``.``) already has its end group and is left untouched, so
+    externally-capped forms such as ``CC{[>][<]CCO[>][<]}O`` pass through
+    unchanged.
+    """
+    repl: Dict[int, Tuple[int, str]] = {}
+    n = len(text)
+    for i, j, inner in _iter_stochastic_objects(text):
+        before = text[i - 1] if i > 0 else ""
+        after = text[j + 1] if j + 1 < n else ""
+        ext_left = before not in ("", ".")
+        ext_right = after not in ("", ".")
+        new = inner
+        if not ext_left and new[:1] == "[" and not new.startswith("[]"):
+            new = "[]" + new
+        if not ext_right and new[-1:] == "]" and not new.endswith("[]"):
+            new = new + "[]"
+        if new != inner:
+            repl[i] = (j, new)
+    return _rebuild(text, repl)
+
+
+def normalize_bigsmiles(bigsmiles_str: str) -> str:
+    """Normalise any accepted BigSMILES notation into the parser's form.
+
+    The ``bigsmiles`` PyPI parser (v0.0.10) only accepts one very verbose
+    spelling: every bonding descriptor bracketed *and* every standalone
+    stochastic object carrying explicit empty end-group placeholders, e.g.
+    ``{[][<]CCCCO[>][]}``. This helper lets users write the far more readable
+    notations from the BigSMILES paper (Lin et al., ACS Cent. Sci. 2019) and
+    converts them to that form internally. It accepts:
+
+    * **Paper full form** (bracketed descriptor, no end-group brackets):
+
+      * ``{[$]CC[$]}``            -> ``{[][$]CC[$][]}``
+      * ``{[<]CCCCO[>]}``         -> ``{[][<]CCCCO[>][]}``
+      * ``{[$]CC(c1ccccc1)[$]}``  -> ``{[][$]CC(c1ccccc1)[$][]}``
+
+    * **Paper simplified form** (descriptor omitted, restored as ``$``):
+
+      * ``{CC}``                  -> ``{[][$]CC[$][]}``
+      * ``{CCO}``                 -> ``{[][$]CCO[$][]}``
+
+    * **BigSMILES v1.0 dialect** (bare descriptors, no brackets) — used e.g. by
+      the Choi et al. homopolymer dataset:
+
+      * ``{<CCCCO>}``             -> ``{[][<]CCCCO[>][]}``
+
+    * The parser's own verbose form and externally-capped objects such as
+      ``CC{[>][<]CCO[>][<]}O`` are returned unchanged, so it is always safe to
+      call.
+
+    Args:
+        bigsmiles_str: A BigSMILES string in any of the notations above.
+
+    Returns:
+        A BigSMILES string in the verbose form the parser accepts.
+    """
+    text = bigsmiles_str.strip()
+    if "{" not in text:
+        return text
+    # 1) Wrap any bare descriptors (v1.0 dialect): ``<`` -> ``[<]``.
+    text = _BARE_DESCRIPTOR.sub(lambda m: f"[{m.group(1)}{m.group(2)}]", text)
+    # 2) Restore the omitted descriptor in the simplified form: ``{CC}`` -> ``{[$]CC[$]}``.
+    text = _expand_simplified(text)
+    # 3) Add empty end-group placeholders to standalone stochastic objects.
+    text = _inject_endgroups(text)
+    return text
+
+
+def parse_bigsmiles(bigsmiles_str: str):
+    """Parse a BigSMILES string into a ``bigsmiles.BigSMILES`` object.
+
+    The input may be in either the modern bracketed dialect
+    (``{[][<]CCO[>][]}``) or the older BigSMILES v1.0 bare-descriptor dialect
+    (``{<CCO>}``); the latter is normalised automatically via
+    :func:`normalize_bigsmiles`.
+
+    Args:
+        bigsmiles_str: The BigSMILES string.
+
+    Returns:
+        A parsed ``bigsmiles.BigSMILES`` object.
+
+    Raises:
+        ValueError: If the string is empty or cannot be parsed.
+    """
+    bs_mod = require_bigsmiles()
+    if not bigsmiles_str or not isinstance(bigsmiles_str, str):
+        raise ValueError("BigSMILES cannot be None or empty")
+    normalized = normalize_bigsmiles(bigsmiles_str)
+    try:
+        return bs_mod.BigSMILES(normalized)
+    except Exception as exc:  # bigsmiles raises a variety of error types
+        raise ValueError(f"Invalid BigSMILES string: {exc}") from exc
+
+
+def is_bonding_descriptor(node) -> bool:
+    """True if ``node`` is a BigSMILES bonding-descriptor atom ([$]/[<]/[>])."""
+    return type(node).__name__ == "BondDescriptorAtom"
+
+
+def is_atom(node) -> bool:
+    """True if ``node`` is a plain BigSMILES atom."""
+    return type(node).__name__ == "Atom"
+
+
+def _walk_atoms_bonds(container, atoms: List, bonds: List) -> Tuple[List, List]:
+    """Recursively collect Atom/BondDescriptorAtom and Bond objects.
+
+    Branches (parenthesised groups) nest inside a fragment and are walked
+    recursively so ring closures and sidechains are captured.
+
+    Args:
+        container: A ``StochasticFragment`` or ``Branch`` exposing ``.nodes``.
+        atoms: Accumulator list for atom-like nodes.
+        bonds: Accumulator list for bond nodes.
+
+    Returns:
+        The ``(atoms, bonds)`` accumulators.
+    """
+    for node in container.nodes:
+        type_name = type(node).__name__
+        if type_name in ("Atom", "BondDescriptorAtom"):
+            atoms.append(node)
+        elif type_name == "Bond":
+            bonds.append(node)
+        elif type_name == "Branch":
+            _walk_atoms_bonds(node, atoms, bonds)
+    return atoms, bonds
+
+
+def _node_key(node) -> Tuple[str, int]:
+    """Composite key for a graph node.
+
+    ``Atom.id_`` and ``BondDescriptorAtom.id_`` are numbered independently and
+    collide, so we key by ``(type_name, id_)``.
+    """
+    return (type(node).__name__, node.id_)
+
+
+def fragment_to_nx(fragment) -> nx.Graph:
+    """Convert a BigSMILES ``StochasticFragment`` to a NetworkX graph.
+
+    Bonding-descriptor atoms are emitted with ``element="*"`` so the existing
+    ``classify_backbone_and_sidechains`` treats them as connection points. Real
+    atoms carry the same node attributes as ``Polymer._mol_to_nx``
+    (``atomic_num``, ``element``, ``is_aromatic``, ``formal_charge``) plus the
+    bonding-descriptor label where relevant.
+
+    Args:
+        fragment: A ``bigsmiles`` ``StochasticFragment`` object.
+
+    Returns:
+        A NetworkX graph representing the repeat unit.
+    """
+    graph = nx.Graph()
+    atoms, bonds = _walk_atoms_bonds(fragment, [], [])
+    # Ring-closure bonds are stored on ``fragment.rings`` rather than in the
+    # ``.nodes`` walk, so add them explicitly (otherwise aromatic/aliphatic
+    # rings come out as open chains and lose a bond).
+    for ring_bond in getattr(fragment, "rings", []) or []:
+        if ring_bond not in bonds:
+            bonds.append(ring_bond)
+
+    for node in atoms:
+        key = _node_key(node)
+        if is_bonding_descriptor(node):
+            graph.add_node(
+                key,
+                element="*",
+                atomic_num=0,
+                is_aromatic=False,
+                formal_charge=0,
+                descriptor=str(node.descriptor),
+            )
+        else:
+            graph.add_node(
+                key,
+                element=node.symbol,
+                atomic_num=_PT.GetAtomicNumber(node.symbol),
+                is_aromatic=bool(node.aromatic),
+                formal_charge=int(node.charge),
+            )
+
+    for bond in bonds:
+        graph.add_edge(
+            _node_key(bond.atom1),
+            _node_key(bond.atom2),
+            bond_type=_BOND_TYPE_MAP.get(bond.symbol, Chem.BondType.SINGLE),
+            bigsmiles_symbol=bond.symbol,
+        )
+    return graph
+
+
+def stochastic_fragment_graphs(bigsmiles_obj) -> List[Tuple[Any, nx.Graph]]:
+    """Enumerate every repeat unit (stochastic fragment) as a graph.
+
+    A BigSMILES string may contain several stochastic objects, and each object
+    may hold several fragments (a copolymer). Each fragment is one repeat unit.
+
+    Args:
+        bigsmiles_obj: A parsed ``bigsmiles.BigSMILES`` object.
+
+    Returns:
+        A list of ``(fragment, graph)`` tuples, in document order.
+    """
+    results = []
+    for node in bigsmiles_obj.nodes:
+        if type(node).__name__ == "StochasticObject":
+            for fragment in node.nodes:
+                if type(fragment).__name__ == "StochasticFragment":
+                    results.append((fragment, fragment_to_nx(fragment)))
+    return results
+
+
+def repeat_unit_graphs(bigsmiles_str: str) -> List[Tuple[Any, nx.Graph]]:
+    """Enumerate every repeat unit of a BigSMILES string as a graph.
+
+    This is the string-level entry point used by :class:`BigSmilesPolymer`. It
+    distinguishes the two ways copolymers are written in the BigSMILES paper
+    (Lin et al., *ACS Cent. Sci.* 2019):
+
+    * **Random copolymer** — one stochastic object with comma-separated
+      fragments, e.g. ``{[$]CC[$],[$]CC(c1ccccc1)[$]}``.
+    * **Block copolymer** — direct concatenation of stochastic objects, e.g.
+      ``{[$]CC[$]}{[$]CC(c1ccccc1)[$]}`` (Figure 4c).
+
+    When several objects are concatenated, the parser fuses the two facing
+    bonding descriptors at each block junction into a single inter-block bond,
+    which would leave the flanking repeat units with only one ``*`` connection
+    point and break backbone tracing. To classify each block on its own terms,
+    every top-level ``{...}`` object is parsed **standalone** (which re-caps it
+    with ``[]`` end groups and restores both connection points). A single
+    object — the homopolymer and random-copolymer case — is parsed once,
+    unchanged.
+
+    Args:
+        bigsmiles_str: A raw BigSMILES string (any accepted notation).
+
+    Returns:
+        A list of ``(fragment, graph)`` tuples, one per repeat unit, in
+        document order.
+    """
+    normalized = normalize_bigsmiles(bigsmiles_str)
+    objects = list(_iter_stochastic_objects(normalized))
+    if not objects:
+        return []
+    # Parse every stochastic object standalone. This is uniformly robust:
+    #   * homopolymers and random copolymers (comma-separated fragments inside
+    #     one object) parse as-is;
+    #   * externally end-capped objects (e.g. ``CC{[$]...[$]}Br`` from an ATRP
+    #     or RAFT polymer) drop the caps, which the parser needs to treat the
+    #     object on its own;
+    #   * block copolymers (concatenated objects) avoid the junction
+    #     descriptor fusion that would otherwise strip a connection point from
+    #     each interior block.
+    # ``inner`` already carries the object's own end-group placeholders after
+    # normalisation, so ``{ + inner + }`` is a valid standalone object.
+    results = []
+    for _, _, inner in objects:
+        standalone = "{" + inner + "}"
+        results.extend(stochastic_fragment_graphs(parse_bigsmiles(standalone)))
+    return results
+
+
+def end_group_atoms(bigsmiles_obj) -> List[str]:
+    """Return element symbols of explicit end-group atoms (top-level atoms).
+
+    In ``CC{[>][<]CCO[>][<]}O`` the leading ``CC`` and trailing ``O`` are
+    explicit end groups living outside the stochastic object.
+
+    Args:
+        bigsmiles_obj: A parsed ``bigsmiles.BigSMILES`` object.
+
+    Returns:
+        A list of element symbols for the top-level (end-group) atoms.
+    """
+    return [
+        node.symbol for node in bigsmiles_obj.nodes if type(node).__name__ == "Atom"
+    ]
+
+
+def graph_to_mol(graph: nx.Graph, node_keys: List[Tuple[str, int]]) -> Chem.Mol:
+    """Build an RDKit molecule from a subset of graph nodes.
+
+    Bonding-descriptor nodes (``element="*"``) become dummy atoms (atomic
+    number 0, RDKit ``*``), exactly mirroring the ``*``-terminated fragments
+    that the pSMILES ``Polymer._extract_substructure_mol`` produces, so the
+    descriptor-based featurizers behave identically.
+
+    Args:
+        graph: The full repeat-unit graph.
+        node_keys: The node keys to include in the molecule.
+
+    Returns:
+        An RDKit ``Mol`` (possibly empty).
+    """
+    if not node_keys:
+        return Chem.MolFromSmiles("")
+
+    mol = RWMol()
+    key_to_idx: Dict[Tuple[str, int], int] = {}
+    node_set = set(node_keys)
+
+    for key in node_keys:
+        data = graph.nodes[key]
+        atom = Atom(int(data.get("atomic_num", 0)))
+        atom.SetFormalCharge(int(data.get("formal_charge", 0)))
+        if data.get("is_aromatic"):
+            atom.SetIsAromatic(True)
+        key_to_idx[key] = mol.AddAtom(atom)
+
+    for u, v, edata in graph.edges(data=True):
+        if u in node_set and v in node_set:
+            mol.AddBond(
+                key_to_idx[u],
+                key_to_idx[v],
+                edata.get("bond_type", Chem.BondType.SINGLE),
+            )
+    return mol.GetMol()
+
+
+def mol_to_smiles(mol: Chem.Mol) -> str:
+    """Be canonical SMILES for a reconstructed fragment mol.
+
+    Sanitisation is attempted but not required; on failure the unsanitised
+    SMILES is returned so serialisation never crashes on an odd fragment.
+
+    Args:
+        mol: An RDKit molecule.
+
+    Returns:
+        A SMILES string (empty string for an empty mol).
+    """
+    if mol is None or mol.GetNumAtoms() == 0:
+        return ""
+    try:
+        work = Chem.Mol(mol)
+        Chem.SanitizeMol(work)
+        return Chem.MolToSmiles(work)
+    except Exception:
+        try:
+            return Chem.MolToSmiles(mol, canonical=False)
+        except Exception:
+            return ""

--- a/src/polymetrix/bigsmiles/bigsmiles_utils.py
+++ b/src/polymetrix/bigsmiles/bigsmiles_utils.py
@@ -48,7 +48,10 @@ def _iter_stochastic_objects(text: str):
     i, n = 0, len(text)
     while i < n:
         if text[i] == "{":
-            j = text.index("}", i)
+            try:
+                j = text.index("}", i)
+            except ValueError as exc:
+                raise ValueError("Unmatched '{' in BigSMILES string") from exc
             yield i, j, text[i + 1 : j]
             i = j + 1
         else:

--- a/tests/test_bigsmiles_polymer.py
+++ b/tests/test_bigsmiles_polymer.py
@@ -1,0 +1,361 @@
+import json
+
+import pytest
+import networkx as nx
+from rdkit import Chem
+
+bigsmiles = pytest.importorskip("bigsmiles")
+
+from polymetrix.bigsmiles import BigSmilesPolymer, RepeatUnit
+from polymetrix.featurizers.polymer import Polymer
+from polymetrix.featurizers.sidechain_backbone_featurizer import (
+    SideChainFeaturizer,
+    NumSideChainFeaturizer,
+    BackBoneFeaturizer,
+    FullPolymerFeaturizer,
+)
+from polymetrix.featurizers.chemical_featurizer import NumAtoms, MolecularWeight
+
+
+# --- parsing -------------------------------------------------------------- #
+def test_bigsmiles_creation():
+    polymer = BigSmilesPolymer.from_bigsmiles("{[][<]CC(c1ccccc1)[>][]}")
+    assert isinstance(polymer, BigSmilesPolymer)
+    assert polymer.bigsmiles == "{[][<]CC(c1ccccc1)[>][]}"
+    assert isinstance(polymer.graph, nx.Graph)
+    assert polymer.num_repeat_units == 1
+    assert not polymer.is_copolymer
+
+
+def test_invalid_bigsmiles():
+    with pytest.raises(ValueError):
+        BigSmilesPolymer.from_bigsmiles("not a bigsmiles")
+
+
+def test_empty_bigsmiles():
+    with pytest.raises(ValueError):
+        BigSmilesPolymer.from_bigsmiles("")
+
+
+def test_no_repeat_unit_raises():
+    # A plain SMILES with no stochastic object has no repeat unit.
+    with pytest.raises(ValueError):
+        BigSmilesPolymer.from_bigsmiles("CCO")
+
+
+# --- classification ------------------------------------------------------- #
+def test_polystyrene_classification():
+    polymer = BigSmilesPolymer.from_bigsmiles("{[][<]CC(c1ccccc1)[>][]}")
+    unit = polymer.repeat_units[0]
+    assert isinstance(unit, RepeatUnit)
+    # one aromatic-ring sidechain
+    assert len(unit.sidechain_molecules) == 1
+    assert Chem.MolToSmiles(_sanitize(unit.sidechain_molecules[0])) == "c1ccccc1"
+
+
+def test_backbone_only_polymer_has_no_sidechain():
+    polymer = BigSmilesPolymer.from_bigsmiles("{[][<]CCO[>][]}")  # PEG
+    _, sidechains = polymer.get_backbone_and_sidechain_molecules()
+    assert all(m.GetNumAtoms() == 0 for m in sidechains) or sidechains == []
+
+
+def test_dollar_descriptor_pdms():
+    polymer = BigSmilesPolymer.from_bigsmiles("{[][$]O[Si](C)(C)[$][]}")
+    assert polymer.num_repeat_units == 1
+    assert polymer.repeat_units[0].descriptors == ["[$]", "[$]"]
+
+
+def test_copolymer_has_two_repeat_units():
+    polymer = BigSmilesPolymer.from_bigsmiles(
+        "{[][<]CC(c1ccccc1)[>],[<]CC(C(=O)OC)(C)[>][]}"
+    )
+    assert polymer.num_repeat_units == 2
+    assert polymer.is_copolymer
+    backbones, sidechains = polymer.get_backbone_and_sidechain_molecules()
+    assert len(backbones) == 2
+    assert len(sidechains) == 2
+
+
+# --- interface parity with Polymer --------------------------------------- #
+def test_get_backbone_and_sidechain_molecules_shape():
+    polymer = BigSmilesPolymer.from_bigsmiles("{[][<]CC(c1ccccc1)[>][]}")
+    backbone, sidechains = polymer.get_backbone_and_sidechain_molecules()
+    assert isinstance(backbone[0], Chem.Mol)
+    assert isinstance(sidechains[0], Chem.Mol)
+
+
+def test_get_backbone_and_sidechain_graphs():
+    polymer = BigSmilesPolymer.from_bigsmiles("{[][<]CC(c1ccccc1)[>][]}")
+    backbones, sidechains = polymer.get_backbone_and_sidechain_graphs()
+    assert isinstance(backbones[0], nx.Graph)
+    assert isinstance(sidechains[0], nx.Graph)
+
+
+def test_psmiles_bridge():
+    polymer = BigSmilesPolymer.from_bigsmiles("{[][<]CC(c1ccccc1)[>][]}")
+    # canonical pSMILES of polystyrene repeat unit
+    assert Chem.CanonSmiles(polymer.psmiles) == Chem.CanonSmiles("*CC(*)c1ccccc1")
+
+
+def test_molecular_weight_positive():
+    polymer = BigSmilesPolymer.from_bigsmiles("{[][<]CC(c1ccccc1)[>][]}")
+    assert polymer.calculate_molecular_weight() > 0
+
+
+# --- featurizer integration (unmodified featurizers) --------------------- #
+@pytest.mark.parametrize(
+    "featurizer",
+    [
+        NumSideChainFeaturizer(),
+        BackBoneFeaturizer(NumAtoms()),
+        SideChainFeaturizer(NumAtoms()),
+        FullPolymerFeaturizer(NumAtoms()),
+        FullPolymerFeaturizer(MolecularWeight()),
+    ],
+)
+def test_featurizers_run_on_bigsmiles(featurizer):
+    polymer = BigSmilesPolymer.from_bigsmiles("{[][<]CC(c1ccccc1)[>][]}")
+    result = featurizer.featurize(polymer)
+    assert result is not None
+    assert len(result) >= 1
+
+
+# --- parity with the pSMILES Polymer ------------------------------------- #
+@pytest.mark.parametrize(
+    "psmiles,bigsmiles_str",
+    [
+        ("[*]CC[*]", "{[][<]CC[>][]}"),
+        ("[*]CC([*])c1ccccc1", "{[][<]CC(c1ccccc1)[>][]}"),
+        ("[*]CC([*])(C)C(=O)OC", "{[][<]CC(C(=O)OC)(C)[>][]}"),
+        ("[*]CCO[*]", "{[][<]CCO[>][]}"),
+        ("[*]CC([*])Cl", "{[][<]CC(Cl)[>][]}"),
+    ],
+)
+def test_parity_with_psmiles(psmiles, bigsmiles_str):
+    p = Polymer.from_psmiles(psmiles)
+    b = BigSmilesPolymer.from_bigsmiles(bigsmiles_str)
+    _, p_sc = p.get_backbone_and_sidechain_molecules()
+    _, b_sc = b.get_backbone_and_sidechain_molecules()
+    p_smis = sorted(_smiles(m) for m in p_sc if m.GetNumAtoms())
+    b_smis = sorted(_smiles(m) for m in b_sc if m.GetNumAtoms())
+    assert p_smis == b_smis
+
+
+# --- older-dialect (BigSMILES v1.0) normalisation ------------------------ #
+from polymetrix.bigsmiles.bigsmiles_utils import normalize_bigsmiles
+
+
+@pytest.mark.parametrize(
+    "old_dialect,expected",
+    [
+        ("{<CCCCO>}", "{[][<]CCCCO[>][]}"),
+        ("{<N[Si](C)(C)>}", "{[][<]N[Si](C)(C)[>][]}"),
+        ("{$CC=C(CCCC)C$}", "{[][$]CC=C(CCCC)C[$][]}"),
+        ("{$CC(OCCCCCCCC)$}", "{[][$]CC(OCCCCCCCC)[$][]}"),
+    ],
+)
+def test_normalize_old_dialect(old_dialect, expected):
+    assert normalize_bigsmiles(old_dialect) == expected
+
+
+@pytest.mark.parametrize(
+    "modern",
+    [
+        "{[][<]CCO[>][]}",
+        "{[][<]CC(c1ccccc1)[>][]}",
+        "{[][$]O[Si](C)(C)[$][]}",
+    ],
+)
+def test_normalize_modern_dialect_unchanged(modern):
+    assert normalize_bigsmiles(modern) == modern
+
+
+@pytest.mark.parametrize(
+    "old_dialect",
+    ["{<CCCCO>}", "{<N[Si](C)(C)>}", "{$CC=C(CCCC)C$}", "{$CC(OCCCCCCCC)$}"],
+)
+def test_old_dialect_parses_and_classifies(old_dialect):
+    polymer = BigSmilesPolymer.from_bigsmiles(old_dialect)
+    assert polymer.num_repeat_units == 1
+    # backbone must contain the two connection points
+    assert polymer.repeat_units[0].backbone_smiles.count("*") == 2
+
+
+# --- serialisation -------------------------------------------------------- #
+def test_to_dict_structure():
+    polymer = BigSmilesPolymer.from_bigsmiles("{[][<]CC(c1ccccc1)[>][]}")
+    d = polymer.to_dict()
+    assert d["bigsmiles"] == "{[][<]CC(c1ccccc1)[>][]}"
+    assert d["num_repeat_units"] == 1
+    assert d["repeat_units"][0]["sidechain_smiles"] == ["c1ccccc1"]
+
+
+def test_json_round_trip():
+    polymer = BigSmilesPolymer.from_bigsmiles(
+        "{[][<]CC(c1ccccc1)[>],[<]CC(C(=O)OC)(C)[>][]}"
+    )
+    restored = BigSmilesPolymer.from_json(polymer.to_json())
+    assert restored.to_dict() == polymer.to_dict()
+
+
+def test_from_dict_round_trip():
+    polymer = BigSmilesPolymer.from_bigsmiles("{[][<]CCO[>][]}")
+    restored = BigSmilesPolymer.from_dict(polymer.to_dict())
+    assert restored.bigsmiles == polymer.bigsmiles
+    assert restored.to_dict() == polymer.to_dict()
+
+
+# --- paper notation (ACS Cent. Sci. 2019) --------------------------------- #
+@pytest.mark.parametrize(
+    "paper,expected",
+    [
+        # full form: bracketed descriptor, no end-group brackets
+        ("{[$]CC[$]}", "{[][$]CC[$][]}"),
+        ("{[<]CCCCO[>]}", "{[][<]CCCCO[>][]}"),
+        ("{[$]CC(c1ccccc1)[$]}", "{[][$]CC(c1ccccc1)[$][]}"),
+        # simplified form: descriptor omitted, restored as $
+        ("{CC}", "{[][$]CC[$][]}"),
+        ("{CCO}", "{[][$]CCO[$][]}"),
+        ("{CC(c1ccccc1)}", "{[][$]CC(c1ccccc1)[$][]}"),
+        # copolymer, full form
+        (
+            "{[$]CC(c1ccccc1)[$],[$]CC(C(=O)OC)(C)[$]}",
+            "{[][$]CC(c1ccccc1)[$],[$]CC(C(=O)OC)(C)[$][]}",
+        ),
+    ],
+)
+def test_normalize_paper_notation(paper, expected):
+    assert normalize_bigsmiles(paper) == expected
+
+
+def test_externally_capped_object_unchanged():
+    # a stochastic object bonded to real end atoms already has its end groups
+    capped = "CC{[>][<]CCO[>][<]}O"
+    assert normalize_bigsmiles(capped) == capped
+
+
+@pytest.mark.parametrize(
+    "paper,backbone,sidechains",
+    [
+        ("{CC}", "*CC*", []),
+        ("{CCO}", "*CCO*", []),
+        ("{[$]CC(c1ccccc1)[$]}", "*CC*", ["c1ccccc1"]),
+        ("{[$]CC(C(=O)OC)(C)[$]}", "*CC(*)C", ["COC=O"]),
+        ("{[$]O[Si](C)(C)[$]}", "*O[Si](*)(C)C", []),
+    ],
+)
+def test_paper_notation_classifies(paper, backbone, sidechains):
+    polymer = BigSmilesPolymer.from_bigsmiles(paper)
+    unit = polymer.repeat_units[0]
+    assert unit.backbone_smiles == backbone
+    assert unit.sidechain_smiles == sidechains
+
+
+@pytest.mark.parametrize(
+    "paper_form,verbose_form",
+    [
+        ("{CC}", "{[][<]CC[>][]}"),
+        ("{[$]CC(c1ccccc1)[$]}", "{[][<]CC(c1ccccc1)[>][]}"),
+        ("{[$]CC(C(=O)OC)(C)[$]}", "{[][<]CC(C(=O)OC)(C)[>][]}"),
+    ],
+)
+def test_paper_and_verbose_forms_agree(paper_form, verbose_form):
+    """The clean paper notation classifies identically to the verbose form."""
+    a = BigSmilesPolymer.from_bigsmiles(paper_form)
+    b = BigSmilesPolymer.from_bigsmiles(verbose_form)
+    assert a.repeat_units[0].backbone_smiles == b.repeat_units[0].backbone_smiles
+    assert a.repeat_units[0].sidechain_smiles == b.repeat_units[0].sidechain_smiles
+    assert abs(a.calculate_molecular_weight() - b.calculate_molecular_weight()) < 1e-6
+
+
+# --- copolymer architecture (random vs block) ---------------------------- #
+@pytest.mark.parametrize(
+    "bigsmiles_str, expected_type, n_units",
+    [
+        ("{[$]CC(c1ccccc1)[$]}", "homopolymer", 1),
+        ("{[$]CC(c1ccccc1)[$],[$]CC(C(=O)OC)(C)[$]}", "random", 2),
+        ("{[$]CC[$]}{[$]CC(c1ccccc1)[$]}", "block", 2),
+        ("{[$]CC[$]}{[$]CCO[$]}{[$]CC(c1ccccc1)[$]}", "block", 3),
+    ],
+)
+def test_copolymer_type(bigsmiles_str, expected_type, n_units):
+    """Random (comma) and block (concatenated) copolymers are distinguished."""
+    p = BigSmilesPolymer.from_bigsmiles(bigsmiles_str)
+    assert p.copolymer_type == expected_type
+    assert p.num_repeat_units == n_units
+    assert p.is_copolymer == (n_units > 1)
+
+
+@pytest.mark.parametrize(
+    "bigsmiles_str, backbones",
+    [
+        # Block copolymer: each block classified independently, both stars kept.
+        ("{[$]CC[$]}{[$]CC(c1ccccc1)[$]}", ["*CC*", "*CC*"]),
+        # Triblock PE-b-PEG-b-PS.
+        (
+            "{[$]CC[$]}{[$]CCO[$]}{[$]CC(c1ccccc1)[$]}",
+            ["*CC*", "*CCO*", "*CC*"],
+        ),
+    ],
+)
+def test_block_copolymer_backbones(bigsmiles_str, backbones):
+    """Block copolymers yield non-empty backbones for every block.
+
+    Regression test: concatenated stochastic objects fuse their facing bonding
+    descriptors at each junction, which previously left interior blocks with a
+    single connection point and produced empty backbones.
+    """
+    p = BigSmilesPolymer.from_bigsmiles(bigsmiles_str)
+    assert [u.backbone_smiles for u in p.repeat_units] == backbones
+    for u in p.repeat_units:
+        assert u.backbone_smiles, "backbone must not be empty"
+
+
+def test_block_copolymer_serialization_round_trip():
+    """Block copolymers serialise and reconstruct, preserving copolymer_type."""
+    p = BigSmilesPolymer.from_bigsmiles("{[$]CC[$]}{[$]CC(c1ccccc1)[$]}")
+    restored = BigSmilesPolymer.from_json(p.to_json())
+    assert restored.to_dict() == p.to_dict()
+    assert restored.copolymer_type == "block"
+
+
+@pytest.mark.parametrize(
+    "bigsmiles_str, copoly_type, backbones",
+    [
+        # SI Example 9: polystyrene from ATRP, 1-phenylethyl-bromide initiator
+        # and Br end group flanking the stochastic object.
+        ("CC(c1ccccc1){[$]CC(c1ccccc1)[$]}Br", "homopolymer", ["*CC*"]),
+        # Conjugate-descriptor object with external end groups.
+        ("CC{[<]CCO[>]}O", "homopolymer", ["*CCO*"]),
+        # External end groups flanking two concatenated blocks.
+        (
+            "CCC(C){[$]CC(c1ccccc1)[$]}{[$]CCO[$]}[H]",
+            "block",
+            ["*CC*", "*CCO*"],
+        ),
+    ],
+)
+def test_externally_capped_polymers(bigsmiles_str, copoly_type, backbones):
+    """Polymers with explicit external end groups classify correctly.
+
+    Each stochastic object is parsed standalone, so the flanking end groups
+    (initiator / terminator, as written for real ATRP and RAFT polymers in the
+    BigSMILES SI) do not prevent the object from being recognised.
+    """
+    p = BigSmilesPolymer.from_bigsmiles(bigsmiles_str)
+    assert p.copolymer_type == copoly_type
+    assert [u.backbone_smiles for u in p.repeat_units] == backbones
+
+
+# --- helpers -------------------------------------------------------------- #
+def _sanitize(mol):
+    m = Chem.Mol(mol)
+    Chem.SanitizeMol(m)
+    return m
+
+
+def _smiles(mol):
+    try:
+        return Chem.MolToSmiles(_sanitize(mol))
+    except Exception:
+        return Chem.MolToSmiles(mol, canonical=False)

--- a/tests/test_bigsmiles_polymer.py
+++ b/tests/test_bigsmiles_polymer.py
@@ -1,10 +1,8 @@
-import json
-
-import pytest
 import networkx as nx
+import pytest
 from rdkit import Chem
 
-bigsmiles = pytest.importorskip("bigsmiles")
+pytest.importorskip("bigsmiles")
 
 from polymetrix.bigsmiles import BigSmilesPolymer, RepeatUnit
 from polymetrix.featurizers.polymer import Polymer


### PR DESCRIPTION
## Summary by Sourcery

Add first-class BigSMILES polymer support, including normalization/parsing utilities and a BigSmiles-backed polymer representation compatible with existing featurizers and splitters.

New Features:
- Introduce BigSmilesPolymer and RepeatUnit classes to represent polymers defined via BigSMILES, with backbone/sidechain classification and JSON serialisation.
- Provide utilities to normalise, parse, and convert BigSMILES stochastic fragments into NetworkX graphs and RDKit molecules, bridging BigSMILES to pSMILES-based workflows.

Enhancements:
- Expose BigSMILES functionality via a dedicated polymetrix.bigsmiles public module for easier integration in downstream code.

Build:
- Add an optional 'bigsmies' dependency group including the bigsmiles parser and a compatible setuptools version.

Tests:
- Add an extensive BigSMILES test suite covering parsing, classification parity with pSMILES polymers, dialect/notation normalisation, copolymer architecture detection, featurizer integration, and serialisation round-trips.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BigSMILES polymer support for parsing, normalization, and repeat-unit analysis.
  * Added backbone, sidechain, molecular weight, connection-point, and copolymer architecture information.
  * Added support for homopolymer, random copolymer, and block copolymer classification.
  * Added JSON and dictionary serialization and restoration.
  * Added an optional BigSMILES installation extra.

* **Tests**
  * Added comprehensive coverage for BigSMILES parsing, normalization, polymer analysis, copolymer behavior, and serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->